### PR TITLE
[PHAT-666] - Allow caller to get public key as base16 encoded

### DIFF
--- a/tls/data_source_public_key.go
+++ b/tls/data_source_public_key.go
@@ -26,6 +26,10 @@ func dataSourcePublicKey() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_key_b16": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"public_key_openssh": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/tls/resource_private_key.go
+++ b/tls/resource_private_key.go
@@ -87,6 +87,11 @@ func resourcePrivateKey() *schema.Resource {
 				Computed: true,
 			},
 
+			"public_key_b16": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"public_key_openssh": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/tls/util.go
+++ b/tls/util.go
@@ -2,6 +2,7 @@ package tls
 
 import (
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 
@@ -90,6 +91,9 @@ func readPublicKey(d *schema.ResourceData, rsaKey interface{}) error {
 	d.SetId(hashForState(string((pubKeyBytes))))
 	d.Set("public_key_pem", string(pem.EncodeToMemory(pubKeyPemBlock)))
 
+	b16PubKeyBytes := hex.EncodeToString(pubKeyBytes)
+	d.Set("public_key_b16", string(b16PubKeyBytes))
+
 	sshPubKey, err := ssh.NewPublicKey(publicKey(rsaKey))
 	if err == nil {
 		// Not all EC types can be SSH keys, so we'll produce this only
@@ -97,6 +101,7 @@ func readPublicKey(d *schema.ResourceData, rsaKey interface{}) error {
 		sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
 		d.Set("public_key_openssh", string(sshPubKeyBytes))
 		d.Set("public_key_fingerprint_md5", ssh.FingerprintLegacyMD5(sshPubKey))
+
 	} else {
 		d.Set("public_key_openssh", "")
 		d.Set("public_key_fingerprint_md5", "")


### PR DESCRIPTION
Exposes an additional `public_key_b16` property which gives the public key in a format that can be read by code like 

```
    val keyData = BaseEncoding.base16().decode(keyHex.toUpperCase())
    return KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(keyData))
```
ref:
* https://github.com/tryflux/terraform-provider-tls/pull/1
* https://github.com/tryflux/engineering-infrastructure/pull/301
* https://github.com/tryflux/engineering-terraform/pull/546 (this)